### PR TITLE
Add GitHub Actions workflows for CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI  
+  
+on:  
+  push:  
+    branches: [ main, master ]  
+  pull_request:  
+    branches: [ main, master ]  
+  
+jobs:  
+  build:  
+    runs-on: ubuntu-latest  
+      
+    steps:  
+    - uses: actions/checkout@v3  
+      
+    - name: Install dependencies  
+      run: |  
+        sudo apt-get update  
+        sudo apt-get install -y build-essential cmake libgl1-mesa-dev freeglut3-dev  
+      
+    - name: Configure CMake  
+      run: |  
+        mkdir -p build  
+        cd build  
+        cmake ..  
+      
+    - name: Build  
+      run: |  
+        cd build  
+        make

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release  
+  
+on:  
+  push:  
+    tags:  
+      - 'v*'  
+  
+jobs:  
+  build:  
+    runs-on: ubuntu-latest  
+      
+    steps:  
+    - uses: actions/checkout@v3  
+      
+    - name: Install dependencies  
+      run: |  
+        sudo apt-get update  
+        sudo apt-get install -y build-essential cmake libgl1-mesa-dev freeglut3-dev  
+      
+    - name: Configure CMake  
+      run: |  
+        mkdir -p build  
+        cd build  
+        cmake ..  
+      
+    - name: Build  
+      run: |  
+        cd build  
+        make  
+      
+    - name: Create Release  
+      id: create_release  
+      uses: actions/create-release@v1  
+      env:  
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  
+      with:  
+        tag_name: ${{ github.ref }}  
+        release_name: Release ${{ github.ref }}  
+        draft: false  
+        prerelease: false  
+      
+    - name: Upload Release Asset  
+      uses: actions/upload-release-asset@v1  
+      env:  
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  
+      with:  
+        upload_url: ${{ steps.create_release.outputs.upload_url }}  
+        asset_path: ./build/BallCatcherGame  
+        asset_name: BallCatcherGame  
+        asset_content_type: application/octet-stream


### PR DESCRIPTION
This pull request introduces two GitHub Actions workflows to automate continuous integration (CI) and release processes. The CI workflow ensures builds are tested on pushes and pull requests to the main branches, while the release workflow automates tagging and asset uploads for new releases.

### CI Workflow:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R30): Added a CI workflow triggered by pushes and pull requests to `main` and `master` branches. It includes steps for dependency installation, CMake configuration, and building the project.

### Release Workflow:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R1-R50): Added a release workflow triggered by pushes to tags matching the `v*` pattern. It includes steps for dependency installation, CMake configuration, building the project, creating a GitHub release, and uploading the build artifact as a release asset.