### PR TITLE
Fix: Update GitHub Actions release workflow to include permissions fo…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,33 +1,35 @@
 name: Release  
-  
+
 on:  
   push:  
     tags:  
       - 'v*'  
-  
+
 jobs:  
   build:  
     runs-on: ubuntu-latest  
+    permissions:
+      contents: write
       
     steps:  
     - uses: actions/checkout@v3  
-      
+
     - name: Install dependencies  
       run: |  
         sudo apt-get update  
         sudo apt-get install -y build-essential cmake libgl1-mesa-dev freeglut3-dev  
-      
+
     - name: Configure CMake  
       run: |  
         mkdir -p build  
         cd build  
         cmake ..  
-      
+
     - name: Build  
       run: |  
         cd build  
         make  
-      
+
     - name: Create Release  
       id: create_release  
       uses: actions/create-release@v1  
@@ -38,7 +40,7 @@ jobs:
         release_name: Release ${{ github.ref }}  
         draft: false  
         prerelease: false  
-      
+
     - name: Upload Release Asset  
       uses: actions/upload-release-asset@v1  
       env:  


### PR DESCRIPTION
Workflow configuration changes:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R11-R12): Added `permissions: contents: write` to the `build` job to grant write access to repository contents during the workflow execution.…r writing contents