### PR TITLE
Refactor: Move permissions for writing contents to the top level in G…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,13 @@ on:
     tags:  
       - 'v*'  
 
+permissions:
+  contents: write
+
 jobs:  
   build:  
     runs-on: ubuntu-latest  
-    permissions:
-      contents: write
-      
+
     steps:  
     - uses: actions/checkout@v3  
 


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration in `.github/workflows/release.yml`. The change moves the `permissions` block from within the `build` job to the top-level `on:` section for better organization and clarity on GitHub Actions release workflow